### PR TITLE
iniciais maisusculas inseridas

### DIFF
--- a/gpd-plannig-tool-frontend/src/ui/components/ModalRegisterNewProduct/index.tsx
+++ b/gpd-plannig-tool-frontend/src/ui/components/ModalRegisterNewProduct/index.tsx
@@ -163,13 +163,13 @@ const ModalRegisterNewProduct = forwardRef<ModalRegisterNewProductProps>(
                         id="demo-simple-select-required"
                         value={template}
                         label="Template *"
-                        defaultValue="low"
+                        defaultValue="Low"
                         required
                         onChange={handleChangeTemplate}
                       >
-                        <MenuItem value="low">Low</MenuItem>
-                        <MenuItem value="mid">Mid</MenuItem>
-                        <MenuItem value="high">High</MenuItem>
+                        <MenuItem value="Low">Low</MenuItem>
+                        <MenuItem value="Mid">Mid</MenuItem>
+                        <MenuItem value="High">High</MenuItem>
                       </Select>
                     </FormControl>
                   </Grid>


### PR DESCRIPTION
quando criávamos o produto com o template High e depois íamos editá-lo, o template dele não aparecia no modal de editar produto