### PR TITLE
Task/BE criar insert template

### DIFF
--- a/gpd-plannig-tool-backend/src/insertions/colabInsertions.ts
+++ b/gpd-plannig-tool-backend/src/insertions/colabInsertions.ts
@@ -1,18 +1,17 @@
-import { Colaborador } from "@/dominio/modelos/Colaborador"; // Import the Colaborador model
+import { Colaborador } from "@/dominio/modelos/Colaborador";
 import { faker } from '@faker-js/faker';
-import * as uuid from "uuid"; // Import the uuid library
+import * as uuid from "uuid";
 
-// Function to insert colaboradores into the database for a given role
 async function insertColaboradoresForRole(roleName) {
   try {
     const colaboradores: Array<Colaborador> = [];
     const qtde_colab = 5;
     for (let i = 0; i < qtde_colab; i++) {
-      const nome = faker.person.fullName(); // Generate a random name
-      const departamento = `Dpto${Math.floor(Math.random() * 3) + 1}`; // Random department froom 1 to 3
+      const nome = faker.person.fullName(); 
+      const departamento = `Dpto${Math.floor(Math.random() * 3) + 1}`; 
 
       const colaborador = await Colaborador.create({
-        id: uuid.v4(), // Generate a unique UUID
+        id: uuid.v4(), 
         nome,
         departamento,
         role_name: roleName,
@@ -28,17 +27,20 @@ async function insertColaboradoresForRole(roleName) {
   }
 }
 
-// Insert colaboradores for each role using their respective UUIDs
 async function insertColaboradores() {
   try {
-    // Define the roles and their UUIDs
     const roles = [
       { role_name: 'Developer' },
       { role_name: 'PM' },
       { role_name: 'TL' },
+      { role_name: 'PL' },
+      { role_name: 'UT_LEAD' },
+      { role_name: 'CM' },
+      { role_name: 'FACTORY' },
+      { role_name: 'DATA_ANALYST' },
+      { role_name: 'NETWORK' },
     ];
 
-    // Insert colaboradores for each role
     for (const role of roles) {
       await insertColaboradoresForRole(role.role_name);
     }

--- a/gpd-plannig-tool-backend/src/insertions/roleInsertions.ts
+++ b/gpd-plannig-tool-backend/src/insertions/roleInsertions.ts
@@ -12,7 +12,7 @@ async function insertRoles() {
     });
 
     const dev_role = await Role.create({
-      role_name: 'Developer',
+      role_name: 'DEV',
       description: 'Software Developer',
     });
 
@@ -21,7 +21,36 @@ async function insertRoles() {
       description: 'Tech Lead',
     });
 
-    // Additional role insertions can be added as needed
+    const ut_role = await Role.create({
+      role_name: 'UT_LEAD',
+      description: 'UT Lead',
+    });
+
+    const pl_role = await Role.create({
+      role_name: 'PL',
+      description: 'Project Leader',
+    });
+
+    const da_role = await Role.create({
+      role_name: 'DATA_ANALYST',
+      description: 'Data Analyst',
+    });
+
+    const net_role = await Role.create({
+      role_name: 'NETWORK',
+      description: 'Network',
+    });
+
+    const cm_role = await Role.create({
+      role_name: 'CM',
+      description: 'CM',
+    });
+
+    const fact_role = await Role.create({
+      role_name: 'FACTORY',
+      description: 'Factory resource',
+    });
+
   } catch (error) {
     console.error('Error inserting roles:', error);
   }

--- a/gpd-plannig-tool-backend/src/insertions/templateInsertions.ts
+++ b/gpd-plannig-tool-backend/src/insertions/templateInsertions.ts
@@ -1,0 +1,26 @@
+import { Template } from "@/dominio/modelos/Template";
+import * as fs from 'fs';
+import * as path from 'path';
+
+async function templateInsertions() {
+  const directoryPath = path.join(__dirname, 'templates');
+
+  try {
+    const files = fs.readdirSync(directoryPath);
+
+    const jsonFiles = files.filter(file => path.extname(file).toLowerCase() === '.json');
+
+    for (const file of jsonFiles) {
+      const filePath = path.join(directoryPath, file);
+      const rawData = fs.readFileSync(filePath, 'utf8');
+
+      const templateData = JSON.parse(rawData);
+      templateData.peak_ammount = JSON.stringify(templateData.peak_ammount);
+      await Template.create(templateData);
+    }
+  } catch (error) {
+    console.error('Error inserting templates:', error);
+  }
+}
+
+export { templateInsertions };

--- a/gpd-plannig-tool-backend/src/insertions/templates/high.json
+++ b/gpd-plannig-tool-backend/src/insertions/templates/high.json
@@ -1,0 +1,86 @@
+{
+    "template_type": "high",
+    "sa_idx": 8,
+    "length": 12,
+    "peak_ammount": {
+        "month1": {
+          "PM": "2.0",
+          "TL": "1.0",
+          "DEV": "1.5"
+        },
+        "month2": {
+          "PL": "2.0",
+          "TL": "1.2",
+          "DEV": "1.5",
+          "UT_LEAD": "2.5",
+          "DATA_ANALYST": "2.3"
+        },
+        "month3": {
+          "PL": "2.6",
+          "TL": "1.2",
+          "DEV": "1.5",
+          "UT_LEAD": "2.5",
+          "PM": "2.8"
+        },
+        "month4": {
+          "PL": "2.0",
+          "CM": "3.5",
+          "NETWORK": "4.5",
+          "DEV": "4.0"
+        },
+        "month05": {
+          "PM": "3.0",
+          "TL": "3.0",
+          "DEV": "3.5"
+        },
+        "month6": {
+          "PL": "2.8",
+          "TL": "2.2",
+          "DEV": "3.5",
+          "UT_LEAD": "3.5",
+          "DATA_ANALYST": "3.3"
+        },
+        "month7": {
+          "PL": "2.0",
+          "TL": "2.2",
+          "DEV": "3.5",
+          "UT_LEAD": "2.5",
+          "PM": "3.3"
+        },
+        "month8": {
+          "PL": "4.0",
+          "FACTORY": "3.2",
+          "CM": "3.5",
+          "NETWORK": "2.5",
+          "DEV": "2.3",
+          "TL": "3.0",
+          "DATA_ANALYST": "3.5"
+        },
+        "month9": {
+          "PM": "2.0",
+          "TL": "1.0",
+          "DEV": "1.5"
+        },
+        "month10": {
+          "PL": "2.8",
+          "TL": "3.2",
+          "DEV": "2.5",
+          "UT_LEAD": "2.5",
+          "DATA_ANALYST": "3.3"
+        },
+        "month11": {
+          "PL": "4.0",
+          "TL": "3.2",
+          "DEV": "2.5",
+          "UT_LEAD": "1.5",
+          "PM": "2.3"
+        },
+        "month12": {
+          "PL": "2.0",
+          "FACTORY": "1.2",
+          "CM": "1.5",
+          "NETWORK": "1.5",
+          "DEV": "2.3"
+        }
+      }
+}

--- a/gpd-plannig-tool-backend/src/insertions/templates/low.json
+++ b/gpd-plannig-tool-backend/src/insertions/templates/low.json
@@ -1,0 +1,62 @@
+{
+    "template_type": "low",
+    "sa_idx": 4,
+    "length": 8,
+    "peak_ammount": {
+        "month1": {
+          "PM": "1.0",
+          "TL": "0.5",
+          "DEV": "0.5"
+        },
+        "month2": {
+          "PL": "1.0",
+          "TL": "1.0",
+          "DEV": "1.0",
+          "UT_LEAD": "1.5",
+          "DATA_ANALYST": "1.5"
+        },
+        "month3": {
+          "PL": "2.0",
+          "TL": "0.8",
+          "DEV": "0.5",
+          "UT_LEAD": "1.5",
+          "PM": "1.6"
+        },
+        "month4": {
+          "PL": "1.0",
+          "CM": "2.5",
+          "NETWORK": "2.5",
+          "DEV": "2.8"
+        },
+        "month5": {
+          "PM": "2.0",
+          "TL": "2.0",
+          "DEV": "1.5"
+        },
+        "month6": {
+          "PL": "2.0",
+          "TL": "1.2",
+          "DEV": "1.5",
+          "UT_LEAD": "1.5",
+          "DATA_ANALYST": "2.0"
+        },
+        "month7": {
+          "PL": "1.0",
+          "TL": "1.2",
+          "DEV": "1.5",
+          "UT_LEAD": "1.5",
+          "PM": "2.3"
+        },
+        "month8": {
+          "PL": "2.0",
+          "FACTORY": "1.2",
+          "CM": "1.5",
+          "NETWORK": "1.5",
+          "DEV": "2.0",
+          "TL": "2.0",
+          "UT_LEAD": "2.8",
+          "DATA_ANALYST": "2.4"
+        }
+      }
+      
+}

--- a/gpd-plannig-tool-backend/src/insertions/templates/mid.json
+++ b/gpd-plannig-tool-backend/src/insertions/templates/mid.json
@@ -1,0 +1,58 @@
+{
+    "template_type": "mid",
+    "sa_idx": 6,
+    "length": 10,
+    "peak_ammount": {
+        "month1": {
+          "PM": "0.5"
+        },
+        "month2": {
+          "PL": "0.5",
+          "TL": "0.6",
+          "DEV": "1",
+          "UT_LEAD": "1.0",
+          "DATA_ANALYST": "1.0"
+        },
+        "month3": {
+          "PL": "1.0",
+          "TL": "0.5",
+          "UT_LEAD": "1.0"
+        },
+        "month4": {
+          "PL": "0.5",
+          "CM": "1.0",
+          "NETWORK": "1.0",
+          "DEV": "0.5"
+        },
+        "month5": {
+          "PM": "1.0",
+          "TL": "1.0",
+          "DEV": "1.0"
+        },
+        "month6": {
+          "PL": "0.8",
+          "TL": "0.8",
+          "DEV": "1.0",
+          "UT_LEAD": "0.5"
+        },
+        "month7": {
+          "PM": "1.0",
+          "TL": "1.0",
+          "DEV": "1.0"
+        },
+        "month8": {
+          "PL": "1.0",
+          "TL": "1.2",
+          "UT_LEAD": "1.5",
+          "DATA_ANALYST": "1.6"
+        },
+        "month9": {
+          "TL": "1.0",
+          "DEV": "1.5"
+        },
+        "month10": {
+          "TL": "1.0",
+          "DEV": "1.5"
+        }
+      }      
+}

--- a/gpd-plannig-tool-backend/src/servidor.ts
+++ b/gpd-plannig-tool-backend/src/servidor.ts
@@ -5,8 +5,8 @@ import { Logger } from "@/common/Logger";
 import { gerarConexaoBDSequelize } from "@/infraestrutura/bd";
 
 import { createServer, Server } from "node:http";
+import { templateInsertions } from "./insertions/templateInsertions";
 import { insertRoles } from "./insertions/roleInsertions";
-import { insertColaboradores } from "./insertions/colabInsertions";
 
 /**
  *
@@ -25,9 +25,9 @@ const iniciarAplicacao = async (): Promise<void> => {
     await conexao.sync();
 
     //Povoar DB
-    // insertRoles();
+    insertRoles();
     // insertColaboradores();
-
+    templateInsertions();
 
     servidor.listen(porta, () =>
       logger.info(`SERVIDOR RODANDO VIOLENTAMENTE NA PORTA ${porta}.`)


### PR DESCRIPTION
Estou adicionando o script para adicionar os templates automaticamente sempre que o servidor subir.

Tem um + aqui, que eu fiz com que o script adicione todos os templates que estiverem dentro do diretorio src/insertions/templates -> Isso fica alinhado com aquele cenario de que alguém vai e cria um json como template novo, adiciona nessa pasta e já vai estar no banco quando o app for rodado novamente. Podemos adicionar um botão em algum lugar que atualiza o banco de templates ou algo assim, podemos discutir melhor segunda.

Além disso, meu script anterior de adicionar roles e colaboradores agraciava apenas 3 roles, PM, TL e Developer. Aqui foram duas alterações: primeiro, corrigi o nome de developer para DEV, ficando alinhado com nossos templates. Segundo, adicionei as seguintes roles faltantes: PL, CM, DATA_ANALYST, NETWORK, FACTORY, UT_LEAD, bem como permiti que fossem criados colaborades para cada uma dessas roles.

Esses scripts de inserção são chamados no arquivo servidor.ts. Deixei descomentada a inserção de roles e templates, enquanto que comentei o script de inserção de colabores. Isso porque ele não vai inserir duplicatas desses dois no banco, mas como a criação de colaboradores eh totalmente aleatória, ele adicionaria adoidado no banco vários colabores a cada reset do servidor. Então acho melhor deixar sempre comentado.